### PR TITLE
MAINT: address deprecation warnings in discourse

### DIFF
--- a/assets/javascripts/templates/connectors/topic-footer-main-buttons-before-create/handled-button.hbs
+++ b/assets/javascripts/templates/connectors/topic-footer-main-buttons-before-create/handled-button.hbs
@@ -1,5 +1,5 @@
-{{#if showHandled}}
-  {{#if handled}}
+{{#if this.showHandled}}
+  {{#if this.handled}}
     {{d-button
       class="unhandle"
       icon="times-circle"
@@ -10,7 +10,7 @@
   {{else}}
     {{d-button
       class="handle"
-      icon="check-circle"
+      icon="circle-check"
       action=(action "setUnhandled" false)
       label="unhandled_tagger.handled.title"
       title="unhandled_tagger.handled.help"

--- a/package.json
+++ b/package.json
@@ -6,9 +6,5 @@
   "license": "MIT",
   "devDependencies": {
     "eslint-config-discourse": "^3.1.0"
-  },
-  "engines": {
-    "yarn": ">=1.22.22",
-    "pnpm": ">=7.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,5 +6,9 @@
   "license": "MIT",
   "devDependencies": {
     "eslint-config-discourse": "^3.1.0"
+  },
+  "engines": {
+    "yarn": ">=1.22.22",
+    "pnpm": ">=7.0.0"
   }
 }


### PR DESCRIPTION
Addresses the following deprecation warnings from discourse:
![Screen Shot 2025-02-05 at 11 28 40 AM](https://github.com/user-attachments/assets/3f5f9631-0f73-4007-9429-45f95f09e529)
